### PR TITLE
Add Ruby-level timeout for PhantomJS script

### DIFF
--- a/lib/screencap/phantom.rb
+++ b/lib/screencap/phantom.rb
@@ -1,4 +1,5 @@
 require 'cgi'
+require 'timeout'
 
 module Screencap
   class Phantom
@@ -10,9 +11,38 @@ module Screencap
         output: path
       }.merge(args).collect {|k,v| "#{k}=#{v}"}
       puts RASTERIZE.to_s, params if(args[:debug])
-      result = Phantomjs.run(RASTERIZE.to_s, *params)
-      puts result if(args[:debug])
+
+      if args[:cutoffWait]
+        # The RASTERIZE script uses "cutoffWait" to force terminate
+        # execution, but this will not trigger if PhantomJS crashes.
+        # Add an arbitrary amount of time to "cutoffWait" to give
+        # the RASTERIZE script time to terminate itself in normal
+        # situations.
+        begin
+          Timeout.timeout((args[:cutoffWait] / 1000) + 5) do
+            phantomjs_run(url, params, args)
+          end
+        rescue Timeout::Error => e
+          raise Screencap::Error.new(e)
+        end
+      else
+        phantomjs_run(url, params, args)
+      end
+    end
+
+    # Custom implementation of Phantomjs.run to manually close the IO
+    # stream. Ruby timeout will not work with Phantomjs.run due its use
+    # IO.popen in block form (https://stackoverflow.com/a/17241050).
+    def self.phantomjs_run(url, phantomjs_params, options)
+      io = IO.popen([Phantomjs.path, RASTERIZE.to_s, *phantomjs_params])
+
+      result = io.read
+      puts result if options[:debug]
+
       raise Screencap::Error, "Could not load URL #{url}" if result.match /Unable to load/
+    ensure
+      Process.kill('TERM', io.pid)
+      io.close
     end
 
     def quoted_args(args)

--- a/screencap.gemspec
+++ b/screencap.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'rspec', '~> 2.10'
   gem.add_development_dependency 'rake'
-  gem.add_development_dependency 'phantomjs.rb'
   gem.add_development_dependency 'fastimage'
   gem.add_runtime_dependency 'phantomjs'
 end


### PR DESCRIPTION
`cutoffWait` used as a forced timeout will not execute if PhantomJS crashes. This adds a Ruby-level timeout so the script will abort in these cases rather than hang indefinitely.